### PR TITLE
find now returns an option

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -510,6 +510,7 @@ impl Journey {
         data_storage
             .transport_types()
             .find(self.transport_type_id())
+            .unwrap_or_else(|| panic!("Transport type {:?} not found.", self.transport_type_id()))
     }
 
     pub fn first_stop_id(&self) -> i32 {
@@ -775,7 +776,10 @@ impl JourneyRouteEntry {
     // Functions
 
     pub fn stop<'a>(&'a self, data_storage: &'a DataStorage) -> &Stop {
-        data_storage.stops().find(self.stop_id())
+        data_storage
+            .stops()
+            .find(self.stop_id())
+            .unwrap_or_else(|| panic!("Stop {:?} not found.", self.stop_id()))
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -249,15 +249,16 @@ impl<M: Model<M>> ResourceStorage<M> {
     }
 
     /// unwrap: Do not call this function if the key is not associated with data.
-    pub fn find(&self, k: M::K) -> &M {
-        &self.data().get(&k).unwrap()
+    pub fn find(&self, k: M::K) -> Option<&M> {
+        // TODO: there might be a problem when k is not in data so we can't unwrap here
+        self.data().get(&k)
     }
 
     pub fn entries(&self) -> Vec<&M> {
         self.data.values().collect()
     }
 
-    pub fn resolve_ids(&self, ids: &FxHashSet<M::K>) -> Vec<&M> {
+    pub fn resolve_ids(&self, ids: &FxHashSet<M::K>) -> Option<Vec<&M>> {
         ids.iter().map(|&id| self.find(id)).collect()
     }
 }
@@ -291,7 +292,9 @@ fn create_bit_fields_by_day(
     });
 
     let result = bit_fields.data().keys().fold(map, |mut acc, bit_field_id| {
-        let bit_field = bit_fields.find(*bit_field_id);
+        let bit_field = bit_fields
+            .find(*bit_field_id)
+            .unwrap_or_else(|| panic!("Bitfield id {:?} not found.", bit_field_id));
         let indexes: Vec<usize> = bit_field
             .bits()
             .iter()


### PR DESCRIPTION
This PR changes the signature of the find method in the ResourceStorage type which now becomes an Option because in some instances just unwrapping causes the programs to crash. In particular for for stop_id 8592093 find returns None. 

Note: this might be an error in the HRDF files since the stop_id 8592093 is ontly in the METABHF file and not in the BAHNHOF file.