### PR TITLE
Remove journey_id from hashmap for identifying journeys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "hrdf-parser"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "assert-json-diff",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hrdf-parser"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 
 license-file = "LICENSE"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,27 +15,27 @@ mod tests {
     use super::*;
     use test_log::test;
 
-    //#[test(tokio::test)]
-    //async fn parsing_2024() {
-    //    let _hrdf = Hrdf::new(
-    //        Version::V_5_40_41_2_0_6,
-    //        "https://data.opentransportdata.swiss/en/dataset/timetable-54-2024-hrdf/permalink",
-    //        true,
-    //        None,
-    //    )
-    //    .await
-    //    .unwrap();
-    //}
-    //
-    //#[test(tokio::test)]
-    //async fn parsing_2025() {
-    //    let _hrdf = Hrdf::new(
-    //        Version::V_5_40_41_2_0_7,
-    //        "https://data.opentransportdata.swiss/en/dataset/timetable-54-2025-hrdf/permalink",
-    //        true,
-    //        None,
-    //    )
-    //    .await
-    //    .unwrap();
-    //}
+    #[test(tokio::test)]
+    async fn parsing_2024() {
+        let _hrdf = Hrdf::new(
+            Version::V_5_40_41_2_0_6,
+            "https://data.opentransportdata.swiss/en/dataset/timetable-54-2024-hrdf/permalink",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    #[test(tokio::test)]
+    async fn parsing_2025() {
+        let _hrdf = Hrdf::new(
+            Version::V_5_40_41_2_0_7,
+            "https://data.opentransportdata.swiss/en/dataset/timetable-54-2025-hrdf/permalink",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,27 +15,27 @@ mod tests {
     use super::*;
     use test_log::test;
 
-    #[test(tokio::test)]
-    async fn parsing_2024() {
-        let _hrdf = Hrdf::new(
-            Version::V_5_40_41_2_0_6,
-            "https://data.opentransportdata.swiss/en/dataset/timetable-54-2024-hrdf/permalink",
-            true,
-            None,
-        )
-        .await
-        .unwrap();
-    }
-
-    #[test(tokio::test)]
-    async fn parsing_2025() {
-        let _hrdf = Hrdf::new(
-            Version::V_5_40_41_2_0_7,
-            "https://data.opentransportdata.swiss/en/dataset/timetable-54-2025-hrdf/permalink",
-            true,
-            None,
-        )
-        .await
-        .unwrap();
-    }
+    //#[test(tokio::test)]
+    //async fn parsing_2024() {
+    //    let _hrdf = Hrdf::new(
+    //        Version::V_5_40_41_2_0_6,
+    //        "https://data.opentransportdata.swiss/en/dataset/timetable-54-2024-hrdf/permalink",
+    //        true,
+    //        None,
+    //    )
+    //    .await
+    //    .unwrap();
+    //}
+    //
+    //#[test(tokio::test)]
+    //async fn parsing_2025() {
+    //    let _hrdf = Hrdf::new(
+    //        Version::V_5_40_41_2_0_7,
+    //        "https://data.opentransportdata.swiss/en/dataset/timetable-54-2025-hrdf/permalink",
+    //        true,
+    //        None,
+    //    )
+    //    .await
+    //    .unwrap();
+    //}
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -318,8 +318,10 @@ impl ExchangeTimeAdministration {
 pub struct ExchangeTimeJourney {
     id: i32,
     stop_id: i32,
-    journey_id_1: i32,
-    journey_id_2: i32,
+    journey_legacy_id_1: i32,
+    administration_1: String,
+    journey_legacy_id_2: i32,
+    administration_2: String,
     duration: i16, // Exchange time from journey 1 to journey 2 is in minutes.
     is_guaranteed: bool,
     bit_field_id: Option<i32>,
@@ -331,8 +333,10 @@ impl ExchangeTimeJourney {
     pub fn new(
         id: i32,
         stop_id: i32,
-        journey_id_1: i32,
-        journey_id_2: i32,
+        journey_legacy_id_1: i32,
+        administration_1: String,
+        journey_legacy_id_2: i32,
+        administration_2: String,
         duration: i16,
         is_guaranteed: bool,
         bit_field_id: Option<i32>,
@@ -340,8 +344,10 @@ impl ExchangeTimeJourney {
         Self {
             id,
             stop_id,
-            journey_id_1,
-            journey_id_2,
+            journey_legacy_id_1,
+            administration_1,
+            journey_legacy_id_2,
+            administration_2,
             duration,
             is_guaranteed,
             bit_field_id,
@@ -354,12 +360,20 @@ impl ExchangeTimeJourney {
         self.stop_id
     }
 
-    pub fn journey_id_1(&self) -> i32 {
-        self.journey_id_1
+    pub fn journey_legacy_id_1(&self) -> i32 {
+        self.journey_legacy_id_1
     }
 
-    pub fn journey_id_2(&self) -> i32 {
-        self.journey_id_2
+    pub fn administration_1(&self) -> &str {
+        &self.administration_1
+    }
+
+    pub fn journey_legacy_id_2(&self) -> i32 {
+        self.journey_legacy_id_2
+    }
+
+    pub fn administration_2(&self) -> &str {
+        &self.administration_2
     }
 
     pub fn duration(&self) -> i16 {
@@ -812,7 +826,8 @@ impl JourneyRouteEntry {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct JourneyPlatform {
-    journey_id: i32,
+    journey_legacy_id: i32,
+    administration: String,
     platform_id: i32,
     time: Option<NaiveTime>,
     bit_field_id: Option<i32>,
@@ -820,13 +835,15 @@ pub struct JourneyPlatform {
 
 impl JourneyPlatform {
     pub fn new(
-        journey_id: i32,
+        journey_legacy_id: i32,
+        administration: String,
         platform_id: i32,
         time: Option<NaiveTime>,
         bit_field_id: Option<i32>,
     ) -> Self {
         Self {
-            journey_id,
+            journey_legacy_id,
+            administration,
             platform_id,
             time,
             bit_field_id,
@@ -838,7 +855,7 @@ impl Model<JourneyPlatform> for JourneyPlatform {
     type K = (i32, i32);
 
     fn id(&self) -> Self::K {
-        (self.journey_id, self.platform_id)
+        (self.journey_legacy_id, self.platform_id)
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -333,10 +333,8 @@ impl ExchangeTimeJourney {
     pub fn new(
         id: i32,
         stop_id: i32,
-        journey_legacy_id_1: i32,
-        administration_1: String,
-        journey_legacy_id_2: i32,
-        administration_2: String,
+        (journey_legacy_id_1, administration_1): JourneyId,
+        (journey_legacy_id_2, administration_2): JourneyId,
         duration: i16,
         is_guaranteed: bool,
         bit_field_id: Option<i32>,

--- a/src/parsing/attribute_parser.rs
+++ b/src/parsing/attribute_parser.rs
@@ -183,7 +183,7 @@ fn create_instance(
 
     if let Some(previous) = pk_type_converter.insert(designation.to_owned(), id) {
         log::error!(
-            "Error: previous id {previous} for {designation}. The designation is not unique."
+            "Error: previous id {previous} for {designation}. The designation, {designation}, is not unique."
         );
     }
 

--- a/src/parsing/attribute_parser.rs
+++ b/src/parsing/attribute_parser.rs
@@ -181,7 +181,12 @@ fn create_instance(
         row_a_from_parsed_values(values);
     let id = auto_increment.next();
 
-    pk_type_converter.insert(designation.to_owned(), id);
+    if let Some(previous) = pk_type_converter.insert(designation.to_owned(), id) {
+        log::error!(
+            "Error: previous id {previous} for {designation}. The designation is not unique."
+        );
+    }
+
     Attribute::new(
         id,
         designation.to_owned(),

--- a/src/parsing/direction_parser.rs
+++ b/src/parsing/direction_parser.rs
@@ -74,7 +74,11 @@ fn create_instance(
 
     let id = remove_first_char(&legacy_id).parse::<i32>()?;
 
-    pk_type_converter.insert(legacy_id, id);
+    if let Some(previous) = pk_type_converter.insert(legacy_id.clone(), id) {
+        log::error!(
+            "Error: previous id {previous} for {legacy_id}. The designation is not unique."
+        );
+    }
     Ok(Direction::new(id, name))
 }
 

--- a/src/parsing/direction_parser.rs
+++ b/src/parsing/direction_parser.rs
@@ -75,8 +75,8 @@ fn create_instance(
     let id = remove_first_char(&legacy_id).parse::<i32>()?;
 
     if let Some(previous) = pk_type_converter.insert(legacy_id.clone(), id) {
-        log::error!(
-            "Error: previous id {previous} for {legacy_id}. The designation is not unique."
+        log::warn!(
+            "Warning: previous id {previous} for {legacy_id}. The legacy_id, {legacy_id} is not unique."
         );
     }
     Ok(Direction::new(id, name))

--- a/src/parsing/exchange_journey_parser.rs
+++ b/src/parsing/exchange_journey_parser.rs
@@ -98,12 +98,12 @@ fn create_instance(
     let is_guaranteed: String = values.remove(0).into();
     let bit_field_id: Option<i32> = values.remove(0).into();
 
-    let journey_id_1 = *journeys_pk_type_converter
-        .get(&(journey_id_1, administration_1))
+    let _journey_id_1 = *journeys_pk_type_converter
+        .get(&(journey_id_1, administration_1.clone()))
         .ok_or("Unknown legacy ID")?;
 
-    let journey_id_2 = *journeys_pk_type_converter
-        .get(&(journey_id_2, administration_2))
+    let _journey_id_2 = *journeys_pk_type_converter
+        .get(&(journey_id_2, administration_2.clone()))
         .ok_or("Unknown legacy ID")?;
 
     // TODO: I haven't seen an is_guaranteed field in the doc. Check if this makes sense.
@@ -114,7 +114,9 @@ fn create_instance(
         auto_increment.next(),
         stop_id,
         journey_id_1,
+        administration_1,
         journey_id_2,
+        administration_2,
         duration,
         is_guaranteed,
         bit_field_id,
@@ -202,8 +204,10 @@ mod tests {
             {
                 "id":1,
                 "stop_id": 8501008,
-                "journey_id_1": 1,
-                "journey_id_2": 3,
+                "journey_legacy_id_1": 23057,
+                "administration_1": "000011",
+                "journey_legacy_id_2": 1671,
+                "administration_2": "000011",
                 "duration": 2,
                 "is_guaranteed": false,
                 "bit_field_id": 10
@@ -215,8 +219,10 @@ mod tests {
             {
                 "id":2,
                 "stop_id": 8501120,
-                "journey_id_1": 2,
-                "journey_id_2": 4,
+                "journey_legacy_id_1": 1929,
+                "administration_1": "000011",
+                "journey_legacy_id_2": 24256,
+                "administration_2": "000011",
                 "duration": 999,
                 "is_guaranteed": false,
                 "bit_field_id": null

--- a/src/parsing/exchange_journey_parser.rs
+++ b/src/parsing/exchange_journey_parser.rs
@@ -26,9 +26,10 @@
 /// UMSTEIGZ
 use std::error::Error;
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
+    JourneyId,
     models::{ExchangeTimeJourney, Model},
     parsing::{ColumnDefinition, ExpectedType, FileParser, ParsedValue, RowDefinition, RowParser},
     storage::ResourceStorage,
@@ -52,7 +53,7 @@ fn exchange_journey_row_parser() -> RowParser {
 }
 fn exchange_journey_row_converter(
     parser: FileParser,
-    journeys_pk_type_converter: &FxHashMap<(i32, String), i32>,
+    journeys_pk_type_converter: &FxHashSet<JourneyId>,
 ) -> Result<FxHashMap<i32, ExchangeTimeJourney>, Box<dyn Error>> {
     let auto_increment = AutoIncrement::new();
 
@@ -70,7 +71,7 @@ fn exchange_journey_row_converter(
 
 pub fn parse(
     path: &str,
-    journeys_pk_type_converter: &FxHashMap<(i32, String), i32>,
+    journeys_pk_type_converter: &FxHashSet<JourneyId>,
 ) -> Result<ResourceStorage<ExchangeTimeJourney>, Box<dyn Error>> {
     log::info!("Parsing UMSTEIGZ...");
     let row_parser = exchange_journey_row_parser();
@@ -87,7 +88,7 @@ pub fn parse(
 fn create_instance(
     mut values: Vec<ParsedValue>,
     auto_increment: &AutoIncrement,
-    journeys_pk_type_converter: &FxHashMap<(i32, String), i32>,
+    journeys_pk_type_converter: &FxHashSet<JourneyId>,
 ) -> Result<ExchangeTimeJourney, Box<dyn Error>> {
     let stop_id: i32 = values.remove(0).into();
     let journey_id_1: i32 = values.remove(0).into();
@@ -98,11 +99,11 @@ fn create_instance(
     let is_guaranteed: String = values.remove(0).into();
     let bit_field_id: Option<i32> = values.remove(0).into();
 
-    let _journey_id_1 = *journeys_pk_type_converter
+    let _journey_id_1 = journeys_pk_type_converter
         .get(&(journey_id_1, administration_1.clone()))
         .ok_or("Unknown legacy ID")?;
 
-    let _journey_id_2 = *journeys_pk_type_converter
+    let _journey_id_2 = journeys_pk_type_converter
         .get(&(journey_id_2, administration_2.clone()))
         .ok_or("Unknown legacy ID")?;
 
@@ -113,10 +114,8 @@ fn create_instance(
     Ok(ExchangeTimeJourney::new(
         auto_increment.next(),
         stop_id,
-        journey_id_1,
-        administration_1,
-        journey_id_2,
-        administration_2,
+        (journey_id_1, administration_1),
+        (journey_id_2, administration_2),
         duration,
         is_guaranteed,
         bit_field_id,
@@ -191,11 +190,11 @@ mod tests {
         };
 
         // The journeys_pk_type_converter is dummy and created just for testing purposes
-        let mut journeys_pk_type_converter: FxHashMap<(i32, String), i32> = FxHashMap::default();
-        journeys_pk_type_converter.insert((23057, "000011".to_string()), 1);
-        journeys_pk_type_converter.insert((1929, "000011".to_string()), 2);
-        journeys_pk_type_converter.insert((1671, "000011".to_string()), 3);
-        journeys_pk_type_converter.insert((24256, "000011".to_string()), 4);
+        let mut journeys_pk_type_converter: FxHashSet<JourneyId> = FxHashSet::default();
+        journeys_pk_type_converter.insert((23057, "000011".to_string()));
+        journeys_pk_type_converter.insert((1929, "000011".to_string()));
+        journeys_pk_type_converter.insert((1671, "000011".to_string()));
+        journeys_pk_type_converter.insert((24256, "000011".to_string()));
 
         let data = exchange_journey_row_converter(parser, &journeys_pk_type_converter).unwrap();
         // First row

--- a/src/parsing/journey_parser.rs
+++ b/src/parsing/journey_parser.rs
@@ -344,16 +344,12 @@ fn journey_row_parser() -> RowParser {
     ])
 }
 
-pub fn parse(
-    path: &str,
+fn journey_row_converter(
+    parser: FileParser,
     transport_types_pk_type_converter: &FxHashMap<String, i32>,
     attributes_pk_type_converter: &FxHashMap<String, i32>,
     directions_pk_type_converter: &FxHashMap<String, i32>,
-) -> Result<JourneyAndTypeConverter, Box<dyn Error>> {
-    log::info!("Parsing FPLAN...");
-    let row_parser = journey_row_parser();
-    let parser = FileParser::new(&format!("{path}/FPLAN"), row_parser)?;
-
+) -> Result<(FxHashMap<i32, Journey>, FxHashMap<(i32, String), i32>), Box<dyn Error>> {
     let auto_increment = AutoIncrement::new();
     let mut data = Vec::new();
     let mut pk_type_converter = FxHashMap::default();
@@ -393,6 +389,25 @@ pub fn parse(
 
     let data = Journey::vec_to_map(data);
 
+    Ok((data, pk_type_converter))
+}
+
+pub fn parse(
+    path: &str,
+    transport_types_pk_type_converter: &FxHashMap<String, i32>,
+    attributes_pk_type_converter: &FxHashMap<String, i32>,
+    directions_pk_type_converter: &FxHashMap<String, i32>,
+) -> Result<JourneyAndTypeConverter, Box<dyn Error>> {
+    log::info!("Parsing FPLAN...");
+    let row_parser = journey_row_parser();
+    let parser = FileParser::new(&format!("{path}/FPLAN"), row_parser)?;
+
+    let (data, pk_type_converter) = journey_row_converter(
+        parser,
+        transport_types_pk_type_converter,
+        attributes_pk_type_converter,
+        directions_pk_type_converter,
+    )?;
     Ok((ResourceStorage::new(data), pk_type_converter))
 }
 

--- a/src/parsing/journey_parser.rs
+++ b/src/parsing/journey_parser.rs
@@ -716,11 +716,19 @@ fn set_direction(
 
 // Parsing RowH
 
-fn set_boarding_or_disembarking_exchange_time(mut values: Vec<ParsedValue>, journey: &mut Journey) {
+fn row_h_from_parsed_values(
+    mut values: Vec<ParsedValue>,
+) -> (String, i32, Option<i32>, Option<i32>) {
     let ci_co: String = values.remove(0).into();
     let exchange_time: i32 = values.remove(0).into();
     let from_stop_id: Option<i32> = values.remove(0).into();
     let until_stop_id: Option<i32> = values.remove(0).into();
+
+    (ci_co, exchange_time, from_stop_id, until_stop_id)
+}
+
+fn set_boarding_or_disembarking_exchange_time(values: Vec<ParsedValue>, journey: &mut Journey) {
+    let (ci_co, exchange_time, from_stop_id, until_stop_id) = row_h_from_parsed_values(values);
 
     let metadata_type = if ci_co == "*CI" {
         JourneyMetadataType::ExchangeTimeBoarding
@@ -937,22 +945,6 @@ mod tests {
             "8507000 Bern                         00638                 %".to_string(),
             "8508005 Burgdorf              00652  00653                 %".to_string(),
             "8508008 Herzogenbuchsee       00704  00705                 %".to_string(),
-            "8508100 Langenthal            00710  00712                 %".to_string(),
-            "8500218 Olten                 00724  00730                 %".to_string(),
-            "8503001 Zürich Altstetten     00800  00800                 %".to_string(),
-            "8503000 Zürich HB             00806  00812                 %".to_string(),
-            "0000176 Zimmerberg-Basistunn -00816 -00816                 %".to_string(),
-            "8503202 Thalwil               00821  00821                 %".to_string(),
-            "8503206 Wädenswil             00831  00831                 %".to_string(),
-            "8503209 Pfäffikon SZ          00839  00841                 %".to_string(),
-            "8503221 Siebnen-Wangen        00848  00848                 %".to_string(),
-            "8503225 Ziegelbrücke          00858  00900                 %".to_string(),
-            "8509416 Unterterzen           00910  00911                 %".to_string(),
-            "8509414 Walenstadt            00915  00915                 %".to_string(),
-            "8509411 Sargans               00925  00926                 %".to_string(),
-            "8509004 Bad Ragaz             00930  00930                 %".to_string(),
-            "8509003 Maienfeld             00933  00933                 %".to_string(),
-            "8509002 Landquart             00938  00938                 %".to_string(),
             "8509000 Chur                  00948                        %".to_string(),
         ];
         let parser = FileParser {
@@ -977,104 +969,117 @@ mod tests {
             assert_eq!(Some(8507000), from_stop_id);
             assert_eq!(Some(8509000), until_stop_id);
         }
-        // {
-        //     let (id, _, parsed_values) = parser_iterator.next().unwrap().unwrap();
-        //     assert_eq!(id, RowType::RowC as i32);
-        //     let (from_stop_id, until_stop_id, bit_field_id) =
-        //         row_c_from_parsed_values(parsed_values);
-        //     assert_eq!(Some(8500090), from_stop_id);
-        //     assert_eq!(Some(8503000), until_stop_id);
-        //     assert_eq!(Some(281004), bit_field_id);
-        // }
-        // {
-        //     let (id, _, parsed_values) = parser_iterator.next().unwrap().unwrap();
-        //     assert_eq!(id, RowType::RowD as i32);
-        //     let (designation, from_stop_id, until_stop_id) =
-        //         row_d_from_parsed_values(parsed_values);
-        //     assert_eq!("VR", &designation);
-        //     assert_eq!(Some(8500090), from_stop_id);
-        //     assert_eq!(Some(8503000), until_stop_id);
-        // }
-        // {
-        //     let (id, _, parsed_values) = parser_iterator.next().unwrap().unwrap();
-        //     assert_eq!(id, RowType::RowD as i32);
-        //     let (designation, from_stop_id, until_stop_id) =
-        //         row_d_from_parsed_values(parsed_values);
-        //     assert_eq!("WR", &designation);
-        //     assert_eq!(Some(8500090), from_stop_id);
-        //     assert_eq!(Some(8503000), until_stop_id);
-        // }
-        // {
-        //     let (id, _, parsed_values) = parser_iterator.next().unwrap().unwrap();
-        //     assert_eq!(id, RowType::RowE as i32);
-        //     let (
-        //         code,
-        //         from_stop_id,
-        //         until_stop_id,
-        //         bit_field_id,
-        //         information_text_id,
-        //         departure_time,
-        //         arrival_time,
-        //     ) = row_e_from_parsed_values(parsed_values);
-        //     assert_eq!("JY", &code);
-        //     assert_eq!(None, from_stop_id);
-        //     assert_eq!(None, until_stop_id);
-        //     assert_eq!(None, bit_field_id);
-        //     assert_eq!(0, information_text_id);
-        //     assert_eq!(None, departure_time);
-        //     assert_eq!(None, arrival_time);
-        // }
-        // {
-        //     let (id, _, parsed_values) = parser_iterator.next().unwrap().unwrap();
-        //     assert_eq!(id, RowType::RowG as i32);
-        //     let (
-        //         direction_type,
-        //         direction_id,
-        //         from_stop_id,
-        //         until_stop_id,
-        //         departure_time,
-        //         arrival_time,
-        //     ) = row_g_from_parsed_values(parsed_values);
-        //     // "*R H                                                       %".to_string(),
-        //     assert_eq!("H", &direction_type);
-        //     assert_eq!("", &direction_id);
-        //     assert_eq!(None, from_stop_id);
-        //     assert_eq!(None, until_stop_id);
-        //     assert_eq!(None, departure_time);
-        //     assert_eq!(None, arrival_time);
-        // }
-        // {
-        //     let (id, _, parsed_values) = parser_iterator.next().unwrap().unwrap();
-        //     assert_eq!(id, RowType::RowI as i32);
-        //     let (stop_id, arrival_time, departure_time) = row_i_from_parsed_values(parsed_values);
-        //     assert_eq!(8500090, stop_id);
-        //     assert_eq!(None, arrival_time);
-        //     assert_eq!(Some(740), departure_time);
-        // }
-        // {
-        //     let (id, _, parsed_values) = parser_iterator.next().unwrap().unwrap();
-        //     assert_eq!(id, RowType::RowI as i32);
-        //     let (stop_id, arrival_time, departure_time) = row_i_from_parsed_values(parsed_values);
-        //     assert_eq!(8500010, stop_id);
-        //     assert_eq!(Some(748), arrival_time);
-        //     assert_eq!(Some(806), departure_time);
-        // }
-        // {
-        //     let (id, _, parsed_values) = parser_iterator.next().unwrap().unwrap();
-        //     assert_eq!(id, RowType::RowI as i32);
-        //     let (stop_id, arrival_time, departure_time) = row_i_from_parsed_values(parsed_values);
-        //     assert_eq!(175, stop_id);
-        //     assert_eq!(Some(-833), arrival_time);
-        //     assert_eq!(Some(-833), departure_time);
-        // }
-        // {
-        //     let (id, _, parsed_values) = parser_iterator.next().unwrap().unwrap();
-        //     assert_eq!(id, RowType::RowI as i32);
-        //     let (stop_id, arrival_time, departure_time) = row_i_from_parsed_values(parsed_values);
-        //     assert_eq!(8503000, stop_id);
-        //     assert_eq!(Some(900), arrival_time);
-        //     assert_eq!(None, departure_time);
-        // }
+        {
+            let (id, _, parsed_values) = parser_iterator.next().unwrap().unwrap();
+            assert_eq!(id, RowType::RowC as i32);
+            let (from_stop_id, until_stop_id, bit_field_id) =
+                row_c_from_parsed_values(parsed_values);
+            assert_eq!(Some(8507000), from_stop_id);
+            assert_eq!(Some(8509000), until_stop_id);
+            assert_eq!(Some(348508), bit_field_id);
+        }
+        {
+            let (id, _, parsed_values) = parser_iterator.next().unwrap().unwrap();
+            assert_eq!(id, RowType::RowD as i32);
+            let (designation, from_stop_id, until_stop_id) =
+                row_d_from_parsed_values(parsed_values);
+            assert_eq!("FS", &designation);
+            assert_eq!(Some(8507000), from_stop_id);
+            assert_eq!(Some(8509000), until_stop_id);
+        }
+        {
+            let (id, _, parsed_values) = parser_iterator.next().unwrap().unwrap();
+            assert_eq!(id, RowType::RowE as i32);
+            let (
+                code,
+                from_stop_id,
+                until_stop_id,
+                bit_field_id,
+                information_text_id,
+                departure_time,
+                arrival_time,
+            ) = row_e_from_parsed_values(parsed_values);
+            assert_eq!("JY", &code);
+            assert_eq!(None, from_stop_id);
+            assert_eq!(None, until_stop_id);
+            assert_eq!(None, bit_field_id);
+            assert_eq!(1370, information_text_id);
+            assert_eq!(None, departure_time);
+            assert_eq!(None, arrival_time);
+        }
+        {
+            let (id, _, parsed_values) = parser_iterator.next().unwrap().unwrap();
+            assert_eq!(id, RowType::RowF as i32);
+            let (line_designation, from_stop_id, until_stop_id, departure_time, arrival_time) =
+                row_f_from_parsed_values(parsed_values);
+            assert_eq!("35", &line_designation);
+            assert_eq!(Some(8507000), from_stop_id);
+            assert_eq!(Some(8509000), until_stop_id);
+            assert_eq!(None, departure_time);
+            assert_eq!(None, arrival_time);
+        }
+        {
+            let (id, _, parsed_values) = parser_iterator.next().unwrap().unwrap();
+            assert_eq!(id, RowType::RowG as i32);
+            let (
+                direction_type,
+                direction_id,
+                from_stop_id,
+                until_stop_id,
+                departure_time,
+                arrival_time,
+            ) = row_g_from_parsed_values(parsed_values);
+            assert_eq!("H", &direction_type);
+            assert_eq!("", &direction_id);
+            assert_eq!(None, from_stop_id);
+            assert_eq!(None, until_stop_id);
+            assert_eq!(None, departure_time);
+            assert_eq!(None, arrival_time);
+        }
+        {
+            let (id, _, parsed_values) = parser_iterator.next().unwrap().unwrap();
+            assert_eq!(id, RowType::RowH as i32);
+            let (ci_co, exchange_time, from_stop_id, until_stop_id) =
+                row_h_from_parsed_values(parsed_values);
+
+            assert_eq!("*CI", &ci_co);
+            assert_eq!(2, exchange_time);
+            assert_eq!(Some(8507000), from_stop_id);
+            assert_eq!(Some(8507000), until_stop_id);
+        }
+        // "8509000 Chur                  00948                        %".to_string(),
+        {
+            let (id, _, parsed_values) = parser_iterator.next().unwrap().unwrap();
+            assert_eq!(id, RowType::RowI as i32);
+            let (stop_id, arrival_time, departure_time) = row_i_from_parsed_values(parsed_values);
+            assert_eq!(8507000, stop_id);
+            assert_eq!(None, arrival_time);
+            assert_eq!(Some(638), departure_time);
+        }
+        {
+            let (id, _, parsed_values) = parser_iterator.next().unwrap().unwrap();
+            assert_eq!(id, RowType::RowI as i32);
+            let (stop_id, arrival_time, departure_time) = row_i_from_parsed_values(parsed_values);
+            assert_eq!(8508005, stop_id);
+            assert_eq!(Some(652), arrival_time);
+            assert_eq!(Some(653), departure_time);
+        }
+        {
+            let (id, _, parsed_values) = parser_iterator.next().unwrap().unwrap();
+            assert_eq!(id, RowType::RowI as i32);
+            let (stop_id, arrival_time, departure_time) = row_i_from_parsed_values(parsed_values);
+            assert_eq!(8508008, stop_id);
+            assert_eq!(Some(704), arrival_time);
+            assert_eq!(Some(705), departure_time);
+        }
+        {
+            let (id, _, parsed_values) = parser_iterator.next().unwrap().unwrap();
+            assert_eq!(id, RowType::RowI as i32);
+            let (stop_id, arrival_time, departure_time) = row_i_from_parsed_values(parsed_values);
+            assert_eq!(8509000, stop_id);
+            assert_eq!(Some(948), arrival_time);
+            assert_eq!(None, departure_time);
+        }
     }
 
     // #[test]

--- a/src/parsing/journey_parser.rs
+++ b/src/parsing/journey_parser.rs
@@ -432,7 +432,11 @@ fn create_instance(
 
     let id = auto_increment.next();
 
-    pk_type_converter.insert((legacy_id, administration.to_owned()), id);
+    if let Some(previous) = pk_type_converter.insert((legacy_id, administration.to_owned()), id) {
+        log::error!(
+            "Error: previous id {previous} for ({legacy_id}, {administration}). The ({legacy_id}, {administration}) is not unique."
+        );
+    };
     Journey::new(id, legacy_id, administration)
 }
 

--- a/src/parsing/platform_parser.rs
+++ b/src/parsing/platform_parser.rs
@@ -311,8 +311,8 @@ fn create_journey_platform(
     let time: Option<i32> = values.remove(0).into();
     let bit_field_id: Option<i32> = values.remove(0).into();
 
-    let journey_id = *journeys_pk_type_converter
-        .get(&(journey_id, administration))
+    let _journey_id = *journeys_pk_type_converter
+        .get(&(journey_id, administration.clone()))
         .ok_or("Unknown legacy journey ID")?;
 
     let platform_id = *platforms_pk_type_converter
@@ -323,6 +323,7 @@ fn create_journey_platform(
 
     Ok(JourneyPlatform::new(
         journey_id,
+        administration,
         platform_id,
         time,
         bit_field_id,
@@ -341,7 +342,12 @@ fn create_platform(
     let id = auto_increment.next();
     let (code, sectors) = parse_platform_data(platform_data)?;
 
-    platforms_pk_type_converter.insert((stop_id, index), id);
+    if let Some(previous) = platforms_pk_type_converter.insert((stop_id, index), id) {
+        log::error!(
+            "Error: previous id {previous} for ({stop_id}, {index}). The ({stop_id}, {index}) is not unique."
+        );
+    };
+
     Ok(Platform::new(id, code, sectors, stop_id))
 }
 

--- a/src/parsing/platform_parser.rs
+++ b/src/parsing/platform_parser.rs
@@ -5,10 +5,10 @@
 // Note: this parser collects both the Platform and JourneyPlatform resources.
 use std::error::Error;
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
-    Version,
+    JourneyId, Version,
     models::{CoordinateSystem, Coordinates, JourneyPlatform, Model, Platform},
     parsing::{
         ColumnDefinition, ExpectedType, FastRowMatcher, FileParser, ParsedValue, RowDefinition,
@@ -136,7 +136,7 @@ fn construct_row_parser(version: Version) -> RowParser {
 pub fn parse(
     version: Version,
     path: &str,
-    journeys_pk_type_converter: &FxHashMap<(i32, String), i32>,
+    journeys_pk_type_converter: &FxHashSet<JourneyId>,
 ) -> Result<(ResourceStorage<JourneyPlatform>, ResourceStorage<Platform>), Box<dyn Error>> {
     log::info!("Parsing GLEIS...");
     let row_parser = construct_row_parser(version);
@@ -301,7 +301,7 @@ fn load_coordinates_for_platforms(
 
 fn create_journey_platform(
     mut values: Vec<ParsedValue>,
-    journeys_pk_type_converter: &FxHashMap<(i32, String), i32>,
+    journeys_pk_type_converter: &FxHashSet<JourneyId>,
     platforms_pk_type_converter: &FxHashMap<(i32, i32), i32>,
 ) -> Result<JourneyPlatform, Box<dyn Error>> {
     let stop_id: i32 = values.remove(0).into();
@@ -311,7 +311,7 @@ fn create_journey_platform(
     let time: Option<i32> = values.remove(0).into();
     let bit_field_id: Option<i32> = values.remove(0).into();
 
-    let _journey_id = *journeys_pk_type_converter
+    let _journey_id = journeys_pk_type_converter
         .get(&(journey_id, administration.clone()))
         .ok_or("Unknown legacy journey ID")?;
 
@@ -343,8 +343,8 @@ fn create_platform(
     let (code, sectors) = parse_platform_data(platform_data)?;
 
     if let Some(previous) = platforms_pk_type_converter.insert((stop_id, index), id) {
-        log::error!(
-            "Error: previous id {previous} for ({stop_id}, {index}). The ({stop_id}, {index}) is not unique."
+        log::warn!(
+            "Warning: previous id {previous} for ({stop_id}, {index}). The pair (stop_id, index), ({stop_id}, {index}), is not unique."
         );
     };
 

--- a/src/parsing/through_service_parser.rs
+++ b/src/parsing/through_service_parser.rs
@@ -3,9 +3,10 @@
 // DURCHBI
 use std::error::Error;
 
-use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 
 use crate::{
+    JourneyId,
     models::{Model, ThroughService},
     parsing::{ColumnDefinition, ExpectedType, FileParser, ParsedValue, RowDefinition, RowParser},
     storage::ResourceStorage,
@@ -14,7 +15,7 @@ use crate::{
 
 pub fn parse(
     path: &str,
-    journeys_pk_type_converter: &FxHashMap<(i32, String), i32>,
+    journeys_pk_type_converter: &FxHashSet<JourneyId>,
 ) -> Result<ResourceStorage<ThroughService>, Box<dyn Error>> {
     log::info!("Parsing DURCHBI...");
     #[rustfmt::skip]
@@ -55,7 +56,7 @@ pub fn parse(
 fn create_instance(
     mut values: Vec<ParsedValue>,
     auto_increment: &AutoIncrement,
-    journeys_pk_type_converter: &FxHashMap<(i32, String), i32>,
+    journeys_pk_type_converter: &FxHashSet<JourneyId>,
 ) -> Result<ThroughService, Box<dyn Error>> {
     let journey_1_id: i32 = values.remove(0).into();
     let journey_1_administration: String = values.remove(0).into();
@@ -65,11 +66,11 @@ fn create_instance(
     let bit_field_id: i32 = values.remove(0).into();
     let journey_2_stop_id: i32 = values.remove(0).into();
 
-    let _journey_1_id = *journeys_pk_type_converter
+    let _journey_1_id = journeys_pk_type_converter
         .get(&(journey_1_id, journey_1_administration.clone()))
         .ok_or("Unknown legacy ID")?;
 
-    let _journey_2_id = *journeys_pk_type_converter
+    let _journey_2_id = journeys_pk_type_converter
         .get(&(journey_2_id, journey_2_administration.clone()))
         .ok_or("Unknown legacy ID")?;
 

--- a/src/parsing/transport_type_parser.rs
+++ b/src/parsing/transport_type_parser.rs
@@ -147,7 +147,7 @@ fn create_instance(
 
     if let Some(previous) = pk_type_converter.insert(designation.to_owned(), id) {
         log::error!(
-            "Error: previous id {previous} for {designation}. The designation is not unique."
+            "Warning: previous id {previous} for {designation}. The designation, {designation}, is not unique."
         );
     };
     TransportType::new(

--- a/src/parsing/transport_type_parser.rs
+++ b/src/parsing/transport_type_parser.rs
@@ -145,7 +145,11 @@ fn create_instance(
 
     let id = auto_increment.next();
 
-    pk_type_converter.insert(designation.to_owned(), id);
+    if let Some(previous) = pk_type_converter.insert(designation.to_owned(), id) {
+        log::error!(
+            "Error: previous id {previous} for {designation}. The designation is not unique."
+        );
+    };
     TransportType::new(
         id,
         designation.to_owned(),

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -58,7 +58,7 @@ pub struct DataStorage {
     bit_field_id_for_through_service_by_journey_id_stop_id:
         FxHashMap<(JourneyId, JourneyId, i32), i32>,
     exchange_times_administration_map: FxHashMap<(Option<i32>, String, String), i32>,
-    exchange_times_journey_map: FxHashMap<(i32, (i32, String), (i32, String)), FxHashSet<i32>>,
+    exchange_times_journey_map: FxHashMap<(i32, JourneyId, JourneyId), FxHashSet<i32>>,
 
     // Additional global data
     default_exchange_time: (i16, i16), // (InterCity exchange time, Exchange time for all other journey types)
@@ -240,7 +240,7 @@ impl DataStorage {
 
     pub fn exchange_times_journey_map(
         &self,
-    ) -> &FxHashMap<(i32, (i32, String), (i32, String)), FxHashSet<i32>> {
+    ) -> &FxHashMap<(i32, JourneyId, JourneyId), FxHashSet<i32>> {
         &self.exchange_times_journey_map
     }
 
@@ -402,7 +402,7 @@ fn create_stop_connections_by_stop_id(
 
 fn create_exchange_times_journey_map(
     exchange_times_journey: &ResourceStorage<ExchangeTimeJourney>,
-) -> FxHashMap<(i32, (i32, String), (i32, String)), FxHashSet<i32>> {
+) -> FxHashMap<(i32, JourneyId, JourneyId), FxHashSet<i32>> {
     exchange_times_journey.entries().into_iter().fold(
         FxHashMap::default(),
         |mut acc, exchange_time| {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -58,7 +58,7 @@ pub struct DataStorage {
     bit_field_id_for_through_service_by_journey_id_stop_id:
         FxHashMap<(JourneyId, JourneyId, i32), i32>,
     exchange_times_administration_map: FxHashMap<(Option<i32>, String, String), i32>,
-    exchange_times_journey_map: FxHashMap<(i32, i32, i32), FxHashSet<i32>>,
+    exchange_times_journey_map: FxHashMap<(i32, (i32, String), (i32, String)), FxHashSet<i32>>,
 
     // Additional global data
     default_exchange_time: (i16, i16), // (InterCity exchange time, Exchange time for all other journey types)
@@ -238,7 +238,9 @@ impl DataStorage {
         &self.exchange_times_administration_map
     }
 
-    pub fn exchange_times_journey_map(&self) -> &FxHashMap<(i32, i32, i32), FxHashSet<i32>> {
+    pub fn exchange_times_journey_map(
+        &self,
+    ) -> &FxHashMap<(i32, (i32, String), (i32, String)), FxHashSet<i32>> {
         &self.exchange_times_journey_map
     }
 
@@ -400,14 +402,20 @@ fn create_stop_connections_by_stop_id(
 
 fn create_exchange_times_journey_map(
     exchange_times_journey: &ResourceStorage<ExchangeTimeJourney>,
-) -> FxHashMap<(i32, i32, i32), FxHashSet<i32>> {
+) -> FxHashMap<(i32, (i32, String), (i32, String)), FxHashSet<i32>> {
     exchange_times_journey.entries().into_iter().fold(
         FxHashMap::default(),
         |mut acc, exchange_time| {
             let key = (
                 exchange_time.stop_id(),
-                exchange_time.journey_id_1(),
-                exchange_time.journey_id_2(),
+                (
+                    exchange_time.journey_legacy_id_1(),
+                    exchange_time.administration_1().to_string(),
+                ),
+                (
+                    exchange_time.journey_legacy_id_2(),
+                    exchange_time.administration_2().to_string(),
+                ),
             );
 
             acc.entry(key).or_default().insert(exchange_time.id());


### PR DESCRIPTION
The tuple legacy_id, admin was not a unique identifier of journeys (many journey were sharing that) so there were matching problems. Now they are not used anymore any we have the desired many possible matching for different parsers like: through_service or platorm.