### PR TITLE
fix example in readme (and add it to compile test)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ assert-json-diff = "2.0.2"
 native-tls = "0.2.14"
 flate2 = "1.0.35"
 zip = "4.0.0"
+tokio = { version = "1.42.0", features = ["rt", "macros"] }
 
 [profile.dev]
 opt-level=3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "hrdf-parser"
 version = "0.5.1"
+authors = ["Florian Burgener"]
 edition = "2024"
-
-license-file = "LICENSE"
 description = "This library is dedicated to the parsing of the HRDF format. For the moment, it can only parse the Swiss version of the HRDF format."
 repository = "https://github.com/florianburgener/hrdf-parser"
-authors = ["Florian Burgener"]
+license-file = "LICENSE"
 
 [dependencies]
 bincode = { version = "2.0.1", features = ["serde"] }
@@ -20,21 +19,19 @@ sha2 = "0.10.9"
 strum = "0.27.2"
 strum_macros = "0.27.2"
 test-log = "0.2.18"
-tokio = { version = "1.47.0", features = ["macros"]}
+tokio = { version = "1.47.0", features = ["macros"] }
 url = "2.5.4"
 zip = "4.3.0"
 
 [dev-dependencies]
-serde_json = "1.0.141"
-pretty_assertions = "1.4.1"
 assert-json-diff = "2.0.2"
-
+flate2 = "1.0.35"
 # For -Zminimal-versions
 native-tls = "0.2.14"
-flate2 = "1.0.35"
+pretty_assertions = "1.4.1"
+serde_json = "1.0.141"
 zip = "4.0.0"
-tokio = { version = "1.42.0", features = ["rt", "macros"] }
 
 [profile.dev]
-opt-level=3
+opt-level = 3
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,23 @@ cargo add hrdf-parser
 
 ## Usage
 
-```rs
+```rust,no_run
+# #[tokio::main(flavor = "current_thread")]
+# async fn main() -> Result<(), Box<dyn core::error::Error>> {
+#
+use hrdf_parser::Hrdf;
+use hrdf_parser::Version;
+
 let hrdf = Hrdf::new(
     Version::V_5_40_41_2_0_5,
     "https://opentransportdata.swiss/en/dataset/timetable-54-2024-hrdf/permalink",
     false,
-    true,
+    None,
 )
 .await?;
+
+#   Ok(())
+# }
 ```
 
 ## Supported HRDF format versions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("../README.md")]
 mod hrdf;
 mod models;
 mod parsing;

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -350,7 +350,7 @@ impl FileParser {
         Ok(lines)
     }
 
-    pub fn parse(&self) -> ParsedRowIterator {
+    pub fn parse(&self) -> ParsedRowIterator<'_> {
         ParsedRowIterator {
             rows_iter: self.rows.iter(),
             row_parser: &self.row_parser,


### PR DESCRIPTION
 - The example on `README.md` now compile
 - `README.md` is now included as root documentation of crate
 - The example is now build when run test

Note : 
 - Only codeblock `rust` is tested, codeblock `rs` is not.
 - I know line started by `# ` isn't hidden on Github, but it is by `cargo doc`. These line is required to test compilation