### PR TITLE
a HTTP 404 not found return an understandable error

### DIFF
--- a/src/hrdf.rs
+++ b/src/hrdf.rs
@@ -65,7 +65,7 @@ impl Hrdf {
                 if !Path::new(&compressed_data_path).exists() {
                     // The data must be downloaded.
                     log::info!("Downloading HRDF data to {compressed_data_path}...");
-                    let response = reqwest::get(url_or_path).await?;
+                    let response = reqwest::get(url_or_path).await?.error_for_status()?;
                     let mut file = std::fs::File::create(&compressed_data_path)?;
                     let mut content = Cursor::new(response.bytes().await?);
                     std::io::copy(&mut content, &mut file)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,26 @@ mod tests {
     use test_log::test;
 
     #[test(tokio::test)]
+    async fn url_not_found() {
+        let hrdf = Hrdf::new(
+            Version::V_5_40_41_2_0_6,
+            "https://data.opentransportdata.swiss/test-should-not-exists",
+            true,
+            None,
+        )
+        .await;
+        match hrdf {
+            Ok(_) => panic!("should be an error"),
+            Err(err) => {
+                assert!(
+                    err.to_string().contains("404 Not Found"),
+                    "The error whould be indicate '404 Not Found'"
+                );
+            }
+        }
+    }
+
+    #[test(tokio::test)]
     async fn parsing_2024() {
         let _hrdf = Hrdf::new(
             Version::V_5_40_41_2_0_6,


### PR DESCRIPTION
Previously, when you pass a false URL to `Hrdf::new`, the error message isn't clear : `invalid Zip archive: Could not find EOCD`

Now is more understandable : `HTTP status client error (404 Not Found) for url (<the url>)`

I've have also add a test